### PR TITLE
Support allowed protocols from bleach 1.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ To configure **mdx_bleach**, pass the following keyword arguments to ``BleachExt
 * ``tags`` Tag Whitelist
 * ``attributes`` Attribute Whitelist
 * ``styles`` Styles Whitelist
+* ``protocols`` Protocols Whitelist
 * ``strip`` Stripping Markup
 * ``strip_comments`` Stripping Comments
 

--- a/README.md
+++ b/README.md
@@ -47,9 +47,9 @@ To configure **mdx_bleach**, pass the following keyword arguments to ``BleachExt
 The following example reflects the default configuration:
 
 ```python
-from mdx_bleach.whitelist import ALLOWED_TAGS, ALLOWED_ATTRIBUTES, ALLOWED_STYLES
+from mdx_bleach.whitelist import ALLOWED_TAGS, ALLOWED_ATTRIBUTES, ALLOWED_STYLES, ALLOWED_PROTOCOLS
 bleach = BleachExtension(tags=ALLOWED_TAGS, attributes=ALLOWED_ATTRIBUTES,
-    styles=ALLOWED_STYLES, strip=False, strip_comments=True)
+    styles=ALLOWED_STYLES, protocols=ALLOWED_PROTOCOLS, strip=False, strip_comments=True)
 md = markdown.Markdown(extensions=[bleach])
 ```
 
@@ -138,6 +138,24 @@ styles = ['color', 'font-weight']
 bleach = BleachExtension(tags=tags, attributes=attrs, styles=styles)
 ```
 
+### Protocol Whitelist
+
+If you allow tags that have attributes containing a URI value
+(like the href attribute of an anchor tag,) you may want to adapt
+the accepted protocols. The default list only allows http, https and mailto.
+
+For example, this sets allowed protocols to http, https and smb:
+
+```python
+protocols = ['http', 'https', 'smb']
+bleach = BleachExtension(protocols=protocols)
+```
+
+This adds smb to the bleach-specified set of allowed protocols:
+
+```python
+bleach = BleachExtension(protocols=ALLOWED_PROTOCOLS + ['smb'])
+```
 
 ### Stripping Markup
 

--- a/mdx_bleach/__init__.py
+++ b/mdx_bleach/__init__.py
@@ -2,7 +2,7 @@
 from mdx_bleach.extension import BleachExtension
 
 
-VERSION = '0.1.0'
+VERSION = '0.1.1'
 
 
 def makeExtension(**kwargs):

--- a/mdx_bleach/extension.py
+++ b/mdx_bleach/extension.py
@@ -1,7 +1,10 @@
 # -*- coding: utf-8 -*-
 from markdown import Extension
-from .whitelist import ALLOWED_TAGS, ALLOWED_ATTRIBUTES, ALLOWED_STYLES
+from .whitelist import (
+    ALLOWED_TAGS, ALLOWED_ATTRIBUTES, ALLOWED_STYLES, ALLOWED_PROTOCOLS
+)
 from .postprocessors import BleachPostprocessor
+from .exceptions import ImproperlyConfigured
 
 class BleachExtension(Extension):
 
@@ -33,6 +36,13 @@ class BleachExtension(Extension):
                 "whitelist styles authors are allowed to set, for example color "
                 "and background-color. The default value is an empty list."
             ],
+            'protocols': [
+                ALLOWED_PROTOCOLS,
+                "If you allow tags that have attributes containing a URI "
+                "value  (like the href attribute of an anchor tag,) you may "
+                "want to adapt the accepted protocols. The default list only "
+                "allows http, https and mailto."
+            ],
             'strip': [
                 False,
                 "By default, Bleach escapes disallowed or invalid markup. If "
@@ -54,7 +64,10 @@ class BleachExtension(Extension):
         tags = self.getConfig('tags', ALLOWED_TAGS)
         attributes = self.getConfig('attributes', ALLOWED_ATTRIBUTES)
         styles = self.getConfig('styles', ALLOWED_STYLES)
+        protocols = self.getConfig('protocols', ALLOWED_PROTOCOLS)
         strip = self.getConfig('strip', False)
         strip_comments = self.getConfig('strip_comments', True)
 
-        md.postprocessors.add('bleach', BleachPostprocessor(md, tags, attributes, styles, strip, strip_comments), '>raw_html')
+        bleach_pp = BleachPostprocessor(md, tags, attributes, styles,
+                                        protocols, strip, strip_comments)
+        md.postprocessors.add('bleach', bleach_pp, '>raw_html')

--- a/mdx_bleach/postprocessors.py
+++ b/mdx_bleach/postprocessors.py
@@ -1,19 +1,29 @@
 import bleach
 from markdown.postprocessors import Postprocessor
-from .whitelist import ALLOWED_TAGS, ALLOWED_ATTRIBUTES, ALLOWED_STYLES
-
+from .whitelist import (
+    ALLOWED_TAGS, ALLOWED_ATTRIBUTES, ALLOWED_STYLES, ALLOWED_PROTOCOLS
+)
 class BleachPostprocessor(Postprocessor):
     """ Sanitize the markdown output. """
 
     def __init__(self, md, tags=ALLOWED_TAGS, attributes=ALLOWED_ATTRIBUTES,
-                 styles=ALLOWED_STYLES, strip=False, strip_comments=True):
+                 styles=ALLOWED_STYLES, protocols=ALLOWED_PROTOCOLS,
+                 strip=False, strip_comments=True):
         self.markdown = md
         self.tags = tags
         self.attributes = attributes
         self.styles = styles
+        self.protocols = protocols,
         self.strip = strip
         self.strip_comments = strip_comments
 
     def run(self, text):
         """ Sanitize the markdown output. """
-        return bleach.clean(text, self.tags, self.attributes, self.styles, self.strip, self.strip_comments)
+        return bleach.clean(text,
+                            tags=self.tags,
+                            attributes=self.attributes,
+                            styles=self.styles,
+                            protocols=self.protocols,
+                            strip=self.strip,
+                            strip_comments=self.strip_comments
+        )

--- a/mdx_bleach/whitelist.py
+++ b/mdx_bleach/whitelist.py
@@ -41,3 +41,10 @@ you will also need to whitelist styles users are allowed to set, for example
 color and background-color.
 """
 ALLOWED_STYLES = []
+
+"""
+If you allow tags that have attributes containing a URI value
+(like the href attribute of an anchor tag,) you may want to adapt
+the accepted protocols. The default list only allows http, https and mailto.
+"""
+ALLOWED_PROTOCOLS = ['http', 'https', 'mailto']

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(
         'mdx_bleach',
     ],
     install_requires=[
-        "bleach >= 1.4.1",
+        "bleach >= 1.5",
         "Markdown >= 2.6.1",
     ],
 

--- a/setup.py
+++ b/setup.py
@@ -20,14 +20,14 @@ except IOError:
 
 setup(
     name='mdx_bleach',
-    version='0.1.0',
+    version='0.1.1',
     description="Python-Markdown extension to sanitize the output of untrusted "
                 "Markdown documents.",
     long_description=LONG_DESCRIPTION,
     author='Sami Turcotte',
     author_email='samiturcotte@gmail.com',
     url='https://github.com/Wenzil/mdx_bleach',
-    download_url='https://github.com/Wenzil/mdx_bleach/tarball/0.1.0',
+    download_url='https://github.com/Wenzil/mdx_bleach/tarball/0.1.1',
     license='MIT License',
     classifiers=(
         "Development Status :: 4 - Beta",


### PR DESCRIPTION
Beginning in bleach 1.5, a parameter (protocols) is added to clean, which creates an incompatibility with mdx_bleach since it uses positional calling syntax.   This version of bleach will be installed with your version requirement, and so mdx_bleach will fail.

I have added support for this parameter and protocol whitelisting to mdx_bleach.  Thanks for creating mdx_bleach!

Regards,
lph  