### PR TITLE
fix errant init definition

### DIFF
--- a/mdx_bleach/postprocessors.py
+++ b/mdx_bleach/postprocessors.py
@@ -13,7 +13,7 @@ class BleachPostprocessor(Postprocessor):
         self.tags = tags
         self.attributes = attributes
         self.styles = styles
-        self.protocols = protocols,
+        self.protocols = protocols
         self.strip = strip
         self.strip_comments = strip_comments
 


### PR DESCRIPTION
Sincerest apologies for a bug I introduced when adding support for protocols in bleach clean.

In the init method of BleachPostprocessor, I inexcusably set self.protocols to a tuple by accidentally appending a comma to the definition.  This tuple is then passed to bleach clean, causing its allowed protocols checks to fail.

Again, I most sincerely apologize for this bug and for causing you work when I was just trying to help.

Regards,
lph